### PR TITLE
Tackle ideas for #5

### DIFF
--- a/src/bonzomatic_launcher.rs
+++ b/src/bonzomatic_launcher.rs
@@ -1,21 +1,27 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+use log::info;
+
 pub enum NetworkMode {
     Sender,
     Grabber,
 }
+
 fn get_network_mode(mode: NetworkMode) -> String {
     match mode {
         NetworkMode::Sender => String::from("networkMode=sender"),
         NetworkMode::Grabber => String::from("networkMode=grabber"),
     }
 }
+
 fn get_server_url(url: &String) -> String {
     format!("serverURL={url}")
 }
+
 pub fn bonzomatic_args(
-    bonzo_dir: &String,
+    bonzo_dir: PathBuf,
+    bonzo_name: String,
     skipdialog: bool,
     network_mode: NetworkMode,
     server_url: &String,
@@ -26,9 +32,19 @@ pub fn bonzomatic_args(
     }
     v.push(get_network_mode(network_mode));
     v.push(get_server_url(server_url));
-    let path: PathBuf = [bonzo_dir, r#"Bonzomatic_W64_GLFW.exe"#].iter().collect();
-    let mut cmd_bonzomatic = Command::new(path);
 
-    cmd_bonzomatic.current_dir(bonzo_dir).args(v);
-    cmd_bonzomatic.spawn().unwrap()
+    let mut cmd_bonzomatic = if cfg!(unix) {
+        let potential_path = bonzo_dir.join(&bonzo_name);
+        if potential_path.is_file() {
+            Command::new(potential_path)
+        } else {
+            info!("Bonzomatic is not found in local folder. Fallback to PATH");
+            Command::new(&bonzo_name)
+        }
+    } else {
+        Command::new(bonzo_dir.join(bonzo_name))
+    };
+
+    cmd_bonzomatic.current_dir(bonzo_dir);
+    cmd_bonzomatic.args(v).spawn().unwrap()
 }


### PR DESCRIPTION
For some unix systems you can install Bonzomatic from a package manager and have it in the PATH. And fallback to it if failed to find executable in the folder
```rust
    let mut cmd_bonzomatic = if cfg!(unix) {
        let potential_path = bonzo_dir.join(&bonzo_name);
        if potential_path.is_file() {
            Command::new(potential_path)
        } else {
            info!("Bonzomatic is not found in local folder. Fallback to PATH");
            Command::new(&bonzo_name)
        }
    } else {
        Command::new(bonzo_dir.join(bonzo_name))
    };
```

I also checked the last [release notes](https://github.com/Gargaj/Bonzomatic/releases/tag/2022-08-20) to find out how they ship Bonzomatic. For windows they include three versions for dx9, dx11 and GLTF respectively! 🙀
So I added a new flag to specify executable name and defaultish values for each platform.
```rust
#[cfg(unix)]
pub const BONZOMATIC_EXE: &str = "bonzomatic";
#[cfg(windows)]
pub const BONZOMATIC_EXE: &str = "Bonzomatic_W64_GLFW.exe";
#[cfg(macos)]
pub const BONZOMATIC_EXE: &str = "Bonzomatic.app";
```

Commit inflated in changes because I match cli commands by value instead of reference. Its get destructed right away and not passed anywhere else.

And added `#![windows_subsystem = "windows"]` to not open terminal. Dunno if it's relevant or not I don't have windows >~> 
https://www.google.com/search?hl=en&q=rust%20windows%20subsytem